### PR TITLE
LPK-7177: Fix incorrect Lupapiste login view URL

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject lupapiste/document-search-commons "2.0.10"
+(defproject lupapiste/document-search-commons "2.0.11"
   :description "Common document search related code shared between lupadoku and onkalo applications"
   :url "https://www.lupapiste.fi"
   :license {:name         "European Union Public License"

--- a/src/clj/search_commons/authorization.clj
+++ b/src/clj/search_commons/authorization.clj
@@ -17,7 +17,7 @@
 
 (defn redirect-response [redirect-path]
   {:status  302
-   :headers {"Location" "/app/fi/welcome#!/login"}
+   :headers {"Location" "/login/fi/"}
    :session {:redirect-after-login redirect-path}})
 
 (defn user-is-authorized? [user required-role]


### PR DESCRIPTION
Technically speaking `/` might suffice. But this might cause redirect loops if you are e.g., running Onkalo locally.